### PR TITLE
[BUGS-4289] Don't report caught exceptions - for 1.0.1 release

### DIFF
--- a/remote_error_monitor.c
+++ b/remote_error_monitor.c
@@ -160,7 +160,8 @@ static void remote_error_monitor_exception_handler(zend_object *exception)
   file = zend_read_property(default_ce, exception, "file", sizeof("file")-1, 0, &rv);
   line = zend_read_property(default_ce, exception, "line", sizeof("line")-1, 0, &rv);
 
-  remote_error_monitor_process(REMOTE_ERROR_MONITOR_EXCEPTION, Z_STRVAL_P(file), Z_LVAL_P(line), Z_STR_P(message), trace_str.s ? ZSTR_VAL(trace_str.s) : "");
+  // We don't want to be reporting caught exceptions.
+  // remote_error_monitor_process(REMOTE_ERROR_MONITOR_EXCEPTION, Z_STRVAL_P(file), Z_LVAL_P(line), Z_STR_P(message), trace_str.s ? ZSTR_VAL(trace_str.s) : "");
 }
 
 

--- a/remote_error_monitor.c
+++ b/remote_error_monitor.c
@@ -176,7 +176,7 @@ PHP_MINIT_FUNCTION(remote_error_monitor)
     old_exception_cb = zend_throw_exception_hook;
 
     zend_error_cb = remote_error_monitor_error_callback;
-    zend_throw_exception_hook = remote_error_monitor_exception_handler;
+    // zend_throw_exception_hook = remote_error_monitor_exception_handler;
   }
 
   return SUCCESS;
@@ -189,7 +189,7 @@ PHP_MSHUTDOWN_FUNCTION(remote_error_monitor)
   // Restore original handlers only if we swapped them
   if(REM_GLOBAL(enabled)) {
     zend_error_cb = old_error_cb;
-    zend_throw_exception_hook = old_exception_cb;
+    // zend_throw_exception_hook = old_exception_cb;
   }
 
   /* PRINT("MODULE SHUTDOWN FUNCTION!"); */

--- a/remote_error_monitor.c
+++ b/remote_error_monitor.c
@@ -169,18 +169,29 @@ PHP_MINIT_FUNCTION(remote_error_monitor)
 {
   /* PRINT("MODULE INIT FUNCTION!"); */
   REGISTER_INI_ENTRIES();
-  old_error_cb = zend_error_cb;
-  old_exception_cb = zend_throw_exception_hook;
-  zend_error_cb = remote_error_monitor_error_callback;
-  zend_throw_exception_hook = remote_error_monitor_exception_handler;
+
+  // Swap out error handlers only if module is enabled
+  if(REM_GLOBAL(enabled)) {
+    old_error_cb = zend_error_cb;
+    old_exception_cb = zend_throw_exception_hook;
+
+    zend_error_cb = remote_error_monitor_error_callback;
+    zend_throw_exception_hook = remote_error_monitor_exception_handler;
+  }
+
   return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(remote_error_monitor)
 {
   UNREGISTER_INI_ENTRIES();
-  zend_error_cb = old_error_cb;
-  zend_throw_exception_hook = old_exception_cb;
+
+  // Restore original handlers only if we swapped them
+  if(REM_GLOBAL(enabled)) {
+    zend_error_cb = old_error_cb;
+    zend_throw_exception_hook = old_exception_cb;
+  }
+
   /* PRINT("MODULE SHUTDOWN FUNCTION!"); */
   return SUCCESS;
 }

--- a/remote_error_monitor.c
+++ b/remote_error_monitor.c
@@ -49,8 +49,12 @@ char *truncate_data(char *input_str, size_t max_len)
   return truncated;
 }
 
-size_t silence_curl_write_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
+size_t remote_error_monitor_curl_write_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
+  // curl writes the response to stdout unless we provide a callback to handle the response
+  // we don't want to do anything with the response
+
+  // return how many bytes were handled. curl treats any value other than what was passed in as an error
   return size;
 }
 
@@ -112,7 +116,9 @@ static void remote_error_monitor_process(int type, const char *error_filename, c
     headerlist = curl_slist_append(headerlist, buf);
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
     curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, silence_curl_write_cb);
+
+    // Prevent CURL writing the response to stdout!!
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, remote_error_monitor_curl_write_cb);
 
     curl_easy_setopt(curl, CURLOPT_URL, REM_GLOBAL(http_server));
     curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, REM_GLOBAL(http_request_timeout));


### PR DESCRIPTION
The exception handler is called for caught exceptions.  Uncaught exceptions fall through to the error handler.  We have many caught exceptions being reported in dashboards for live PHP 8.0 sites.  Commented out the exception handler swap.

Only swap error handler if module is enabled.

Namespace the curl write callback function name.

