### PR TITLE
1.0.3 - default error handler in all environments (remove conditional)

### DIFF
--- a/php_remote_error_monitor.h
+++ b/php_remote_error_monitor.h
@@ -34,7 +34,7 @@
    *
    */
   #define PHP_REMOTE_ERROR_MONITOR_EXTNAME "remote_error_monitor"
-  #define PHP_REMOTE_ERROR_MONITOR_VERSION "1.0.2"
+  #define PHP_REMOTE_ERROR_MONITOR_VERSION "1.0.3"
 
   /* Define the entry point symbol.
    *

--- a/remote_error_monitor.c
+++ b/remote_error_monitor.c
@@ -159,15 +159,8 @@ static void remote_error_monitor_error_callback(int type, const char *error_file
   smart_str_0(&trace_str);
   remote_error_monitor_process(REMOTE_ERROR_MONITOR_ERROR, error_filename, error_lineno, args, trace_str.s ? ZSTR_VAL(trace_str.s) : "");
 
-  // Gentle roll-out: first, do not call the old error handler at all in the live environment.
-  // Once we are ready to enable this on dev / multidev environments, we can change
-  // this check to only call through to the old_error_cb on the live environment
-  // if it was deployed AFTER a given date (and always call through on dev/multidev).
-  // That way folks can preview on dev and only get the updated behavior on live after they deploy.
-  if (!remote_error_monitor_is_live_environment()) {
-    /* Calling saved callback function for error handling */
-    old_error_cb(type, error_filename, error_lineno, args);
-  }
+  /* Calling saved callback function for error handling */
+  old_error_cb(type, error_filename, error_lineno, args);
 }
 
 static void remote_error_monitor_exception_handler(zend_object *exception)


### PR DESCRIPTION
Since cos-runtime-php is building with version tags, this can be merged now (or whenever)