### PR TITLE
Pass PHP's type value in the curl call, rather than hard-coding 1

### DIFF
--- a/remote_error_monitor.c
+++ b/remote_error_monitor.c
@@ -157,7 +157,7 @@ static void remote_error_monitor_error_callback(int type, const char *error_file
   smart_str trace_str = {0};
   //rem_append_backtrace(&trace_str);
   smart_str_0(&trace_str);
-  remote_error_monitor_process(REMOTE_ERROR_MONITOR_ERROR, error_filename, error_lineno, args, trace_str.s ? ZSTR_VAL(trace_str.s) : "");
+  remote_error_monitor_process(type, error_filename, error_lineno, args, trace_str.s ? ZSTR_VAL(trace_str.s) : "");
 
   /* Calling saved callback function for error handling */
   old_error_cb(type, error_filename, error_lineno, args);


### PR DESCRIPTION
`remote_error_monitor_error_callback` is receiving a `type` parameter, [but it's not passing that parameter through](https://github.com/pantheon-systems/php-remote-error-monitor/blob/master/remote_error_monitor.c#L160).  Instead it's passing its own `REMOTE_ERROR_MONITOR_ERROR` constant [which is equal to 1](https://github.com/pantheon-systems/php-remote-error-monitor/blob/6dfce6883f4bc5a9eee9cb02e11a11d8866df6af/php_remote_error_monitor.h#L53).

perhaps it should at least pass the `type` value it receives....